### PR TITLE
MAINT: remove stubbed alignment functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_install:
 install:
   - conda create --yes -n test-env python=$PYTHON_VERSION nose flake8
   - conda install -c qiime2 qiime
-  - conda install -c bioconda mafft
   - conda install -c biocore fasttree
   - source activate test-env
   - pip install https://github.com/qiime2/q2-types/archive/master.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ before_install:
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
   - conda create --yes -n test-env python=$PYTHON_VERSION nose flake8
-  - conda install -c qiime2 qiime
-  - conda install -c biocore fasttree
+  - conda install --yes -c qiime2 qiime
+  - conda install --yes -c biocore fasttree
   - source activate test-env
   - pip install https://github.com/qiime2/q2-types/archive/master.zip
   - pip install .

--- a/q2_phylogeny/_filter.py
+++ b/q2_phylogeny/_filter.py
@@ -1,7 +1,0 @@
-# ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file LICENSE, distributed with this software.
-# ----------------------------------------------------------------------------

--- a/q2_phylogeny/_mafft.py
+++ b/q2_phylogeny/_mafft.py
@@ -1,7 +1,0 @@
-# ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
-#
-# Distributed under the terms of the Modified BSD License.
-#
-# The full license is in the file LICENSE, distributed with this software.
-# ----------------------------------------------------------------------------


### PR DESCRIPTION
This removes the stubbed alignment functionality from the ``q2-phylogeny`` plugin. Initially I thought we'd put both alignment and phylogeny in one plugin, but after discussion with @rob-knight we realized the scope for alignment is big enough that it makes sense to be its own plugin. 

@rob-knight, this one is ready for review/merge. 