### PR TITLE
ENH: improves handling of FastTree failure

### DIFF
--- a/q2_phylogeny/_fasttree.py
+++ b/q2_phylogeny/_fasttree.py
@@ -12,12 +12,23 @@ from q2_types.feature_data import AlignedDNAFASTAFormat
 from q2_types.tree import NewickFormat
 
 
+def run_command(cmd, output_fp, verbose=True):
+    if verbose:
+        print("Running external command line application. This may print "
+              "messages to stdout and/or stderr.")
+        print("The command being run is below. This command cannot "
+              "be manually re-run as it will depend on temporary files that "
+              "no longer exist.")
+        print("\nCommand:", end=' ')
+        print(" ".join(cmd), end='\n\n')
+    with open(output_fp, 'w') as output_f:
+        subprocess.run(cmd, stdout=output_f, check=True)
+
+
 def fasttree(alignment: AlignedDNAFASTAFormat) -> NewickFormat:
     result = NewickFormat()
     aligned_fp = str(alignment)
     tree_fp = str(result)
-    cmd = ['FastTree', '-nt', '-quiet', aligned_fp]
-    # construct phylogenetic tree and write the output file
-    with open(tree_fp, 'w') as tree_f:
-        subprocess.run(cmd, stdout=tree_f)
+    cmd = ['FastTree', '-nt', aligned_fp]
+    run_command(cmd, tree_fp)
     return result

--- a/q2_phylogeny/tests/test_fasttree.py
+++ b/q2_phylogeny/tests/test_fasttree.py
@@ -6,13 +6,18 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import os
 import unittest
 import skbio
+import subprocess
 
 from qiime.plugin.testing import TestPluginBase
+from qiime.util import redirected_stdio
 from q2_types.feature_data import AlignedDNAFASTAFormat
+from q2_types.tree import NewickFormat
 
 from q2_phylogeny import fasttree
+from q2_phylogeny._fasttree import run_command
 
 
 class FastTreeTests(TestPluginBase):
@@ -22,7 +27,8 @@ class FastTreeTests(TestPluginBase):
     def test_fasttree(self):
         input_fp = self.get_data_path('aligned-dna-sequences-1.fasta')
         input_sequences = AlignedDNAFASTAFormat(input_fp, mode='r')
-        obs = fasttree(input_sequences)
+        with redirected_stdio(stderr=os.devnull):
+            obs = fasttree(input_sequences)
         # load the resulting tree and test that it has the right number of
         # tips and the right tip ids (the branch lengths can vary with
         # different versions of FastTree)
@@ -34,6 +40,22 @@ class FastTreeTests(TestPluginBase):
         tip_names.sort()
         self.assertEqual(tip_names, ['seq1', 'seq2'])
 
+
+class RunCommandTests(TestPluginBase):
+
+    package = 'q2_phylogeny.tests'
+
+    def test_failed_run(self):
+        input_fp = self.get_data_path('aligned-dna-sequences-1.fasta')
+        input_sequences = AlignedDNAFASTAFormat(input_fp, mode='r')
+        result = NewickFormat()
+        aligned_fp = str(input_sequences)
+        tree_fp = str(result)
+
+        cmd = ['FastTree', '-nt', '-not-a-real-parameter', aligned_fp]
+        with self.assertRaises(subprocess.CalledProcessError):
+            with redirected_stdio(stderr=os.devnull):
+                run_command(cmd, tree_fp)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
fixes #10 

Test output is noisy, as this no longer captures stdout/stderr. Open to suggestions on how to handle that (nose doesn't support any capture of stderr). 