### PR TITLE
ENH: new date-based versioning; `qiime` -> `qiime2` package rename

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,14 @@ before_install:
   - ./miniconda.sh -b
   - export PATH=/home/travis/miniconda3/bin:$PATH
 install:
-  - conda create --yes -c biocore -n test-env python=$PYTHON_VERSION nose flake8 scikit-bio
+  - conda create --yes -c biocore -n test-env python=$PYTHON_VERSION nose scikit-bio
   - conda install --yes -c biocore fasttree
   - source activate test-env
   - pip install https://github.com/qiime2/qiime2/archive/master.zip https://github.com/qiime2/q2-types/archive/master.zip
+  - pip install flake8
   - pip install .
+  - git clone https://github.com/qiime2/q2lint
 script:
   - nosetests
-  - flake8 q2_phylogeny setup.py
+  - flake8
+  - python q2lint/q2lint.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,6 @@
-Copyright (c) 2016, biocore
+BSD 3-Clause License
+
+Copyright (c) 2016-2017, QIIME 2 development team.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -11,7 +13,7 @@ modification, are permitted provided that the following conditions are met:
   this list of conditions and the following disclaimer in the documentation
   and/or other materials provided with the distribution.
 
-* Neither the name of qiime2 nor the names of its
+* Neither the name of the copyright holder nor the names of its
   contributors may be used to endorse or promote products derived from
   this software without specific prior written permission.
 

--- a/q2_phylogeny/__init__.py
+++ b/q2_phylogeny/__init__.py
@@ -1,15 +1,18 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import pkg_resources
+
 from ._util import midpoint_root
 from ._fasttree import fasttree
 from ._filter import filter_table
 
-__version__ = '0.0.7.dev0'
+
+__version__ = pkg_resources.get_distribution('q2-phylogeny').version
 
 __all__ = ["midpoint_root", "fasttree", "filter_table"]

--- a/q2_phylogeny/_fasttree.py
+++ b/q2_phylogeny/_fasttree.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_phylogeny/_filter.py
+++ b/q2_phylogeny/_filter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_phylogeny/_util.py
+++ b/q2_phylogeny/_util.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -1,12 +1,12 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
-from qiime.plugin import Plugin
+from qiime2.plugin import Plugin
 from q2_types.tree import Phylogeny, Unrooted, Rooted
 from q2_types.feature_data import FeatureData, AlignedSequence
 from q2_types.feature_table import FeatureTable, Frequency

--- a/q2_phylogeny/tests/__init__.py
+++ b/q2_phylogeny/tests/__init__.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/q2_phylogeny/tests/test_fasttree.py
+++ b/q2_phylogeny/tests/test_fasttree.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -11,8 +11,8 @@ import unittest
 import skbio
 import subprocess
 
-from qiime.plugin.testing import TestPluginBase
-from qiime.util import redirected_stdio
+from qiime2.plugin.testing import TestPluginBase
+from qiime2.util import redirected_stdio
 from q2_types.feature_data import AlignedDNAFASTAFormat
 from q2_types.tree import NewickFormat
 
@@ -56,6 +56,7 @@ class RunCommandTests(TestPluginBase):
         with self.assertRaises(subprocess.CalledProcessError):
             with redirected_stdio(stderr=os.devnull):
                 run_command(cmd, tree_fp)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2_phylogeny/tests/test_filter.py
+++ b/q2_phylogeny/tests/test_filter.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -47,6 +47,7 @@ class FilterTableTests(unittest.TestCase):
         actual = filter_table(table, tree)
         expected = table.filter(['O1', 'O2'], axis='observation')
         self.assertEqual(actual, expected)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/q2_phylogeny/tests/test_util.py
+++ b/q2_phylogeny/tests/test_util.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------------
-# Copyright (c) 2016--, QIIME development team.
+# Copyright (c) 2016-2017, QIIME 2 development team.
 #
 # Distributed under the terms of the Modified BSD License.
 #
@@ -10,17 +10,17 @@ from setuptools import setup, find_packages
 
 setup(
     name="q2-phylogeny",
-    # TODO stop duplicating version string
-    version="0.0.7.dev0",
+    version="2017.2.0.dev0",
     packages=find_packages(),
-    install_requires=['scikit-bio', 'qiime >= 2.0.6', 'q2-types >= 0.0.6'],
+    install_requires=['qiime2 == 2017.2.*', 'q2-types == 2017.2.*',
+                      'scikit-bio'],
     author="Greg Caporaso",
     author_email="gregcaporaso@gmail.com",
     description="Create and work with Phylogenetic trees in QIIME 2.",
-    license="BSD",
-    url="http://www.qiime.org",
+    license="BSD-3-Clause",
+    url="https://qiime2.org",
     entry_points={
-        'qiime.plugins': ['q2-phylogeny=q2_phylogeny.plugin_setup:plugin']
+        'qiime2.plugins': ['q2-phylogeny=q2_phylogeny.plugin_setup:plugin']
     },
     package_data={'q2_phylogeny.tests': ['data/*']}
 )


### PR DESCRIPTION
# ~~DO NOT MERGE~~

New date-based versioning scheme is:

- YYYY.M.patch.dev0 for development version (e.g. 2017.2.0.dev0, 2017.2.1.dev0, 2018.10.0.dev0)
- YYYY.M.patch for release version (e.g. 2017.2.0, 2017.2.1, 2018.10.0)

Plugins/interfaces are recommended to specify `qiime2 == YYYY.M.*` in setup.py's `install_requires` to obtain patch releases for a given train release.

The new versioning scheme is PEP 440 compliant.