### PR TITLE
Swap usage of `FastTree` binary to parallel `FastTreeMP`

### DIFF
--- a/q2_phylogeny/_fasttree.py
+++ b/q2_phylogeny/_fasttree.py
@@ -23,8 +23,6 @@ def run_command(cmd, output_fp, verbose=True, env=None):
         print("\nCommand:", end=' ')
         print(" ".join(cmd), end='\n\n')
 
-    if env is None:
-        env = os.environ.copy()
     with open(output_fp, 'w') as output_f:
         subprocess.run(cmd, stdout=output_f, check=True, env=env)
 
@@ -35,9 +33,14 @@ def fasttree(alignment: AlignedDNAFASTAFormat,
     aligned_fp = str(alignment)
     tree_fp = str(result)
 
-    env = os.environ.copy()
-    env.update({'OMP_NUM_THREADS': str(n_threads)})
+    env = None
+    if n_threads == 1:
+        cmd = ['FastTree']
+    else:
+        env = os.environ.copy()
+        env.update({'OMP_NUM_THREADS': str(n_threads)})
+        cmd = ['FastTreeMP']
 
-    cmd = ['FastTreeMP', '-quote', '-nt', aligned_fp]
+    cmd.extend(['-quote', '-nt', aligned_fp])
     run_command(cmd, tree_fp, env=env)
     return result

--- a/q2_phylogeny/_fasttree.py
+++ b/q2_phylogeny/_fasttree.py
@@ -42,12 +42,13 @@ def _env(environ):
         os.environ.update(backup)
 
 
-def fasttree(alignment: AlignedDNAFASTAFormat, threads: int=1) -> NewickFormat:
+def fasttree(alignment: AlignedDNAFASTAFormat,
+             n_threads: int=1) -> NewickFormat:
     result = NewickFormat()
     aligned_fp = str(alignment)
     tree_fp = str(result)
 
-    environ = {'OMP_NUM_THREADS': str(threads)}
+    environ = {'OMP_NUM_THREADS': str(n_threads)}
     with _env(environ):
         cmd = ['FastTreeMP', '-quote', '-nt', aligned_fp]
         run_command(cmd, tree_fp)

--- a/q2_phylogeny/_fasttree.py
+++ b/q2_phylogeny/_fasttree.py
@@ -14,7 +14,7 @@ from q2_types.feature_data import AlignedDNAFASTAFormat
 from q2_types.tree import NewickFormat
 
 
-def run_command(cmd, output_fp, verbose=True, env=None):
+def run_command(cmd, output_fp, verbose=True):
     if verbose:
         print("Running external command line application. This may print "
               "messages to stdout and/or stderr.")
@@ -23,29 +23,29 @@ def run_command(cmd, output_fp, verbose=True, env=None):
               "no longer exist.")
         print("\nCommand:", end=' ')
         print(" ".join(cmd), end='\n\n')
-    if env is None:
-        env = os.environ.copy()
+        
     with open(output_fp, 'w') as output_f:
-        subprocess.run(cmd, stdout=output_f, check=True, env=env)
+        subprocess.run(cmd, stdout=output_f, check=True)
 
 
 @contextlib.contextmanager
-def _env(**environ):
+def _env(environ):
     current = os.environ.copy()
     os.environ.update(environ)
     try:
         yield
     finally:
         os.environ.clear()
-        os.environ.update(old_environ)
+        os.environ.update(current)
+
 
 def fasttree(alignment: AlignedDNAFASTAFormat, threads: int=1) -> NewickFormat:
     result = NewickFormat()
     aligned_fp = str(alignment)
     tree_fp = str(result)
 
-    env = os.environ.copy()
-    with _env({'OMP_NUM_THREADS': threads}):
+    environ = {'OMP_NUM_THREADS': str(threads)} 
+    with _env(environ):
         cmd = ['FastTreeMP', '-quote', '-nt', aligned_fp]
-        run_command(cmd, tree_fp, env)
+        run_command(cmd, tree_fp)
     return result

--- a/q2_phylogeny/_fasttree.py
+++ b/q2_phylogeny/_fasttree.py
@@ -6,13 +6,15 @@
 # The full license is in the file LICENSE, distributed with this software.
 # ----------------------------------------------------------------------------
 
+import os
 import subprocess
+import contextlib
 
 from q2_types.feature_data import AlignedDNAFASTAFormat
 from q2_types.tree import NewickFormat
 
 
-def run_command(cmd, output_fp, verbose=True):
+def run_command(cmd, output_fp, verbose=True, env=None):
     if verbose:
         print("Running external command line application. This may print "
               "messages to stdout and/or stderr.")
@@ -21,14 +23,29 @@ def run_command(cmd, output_fp, verbose=True):
               "no longer exist.")
         print("\nCommand:", end=' ')
         print(" ".join(cmd), end='\n\n')
+    if env is None:
+        env = os.environ.copy()
     with open(output_fp, 'w') as output_f:
-        subprocess.run(cmd, stdout=output_f, check=True)
+        subprocess.run(cmd, stdout=output_f, check=True, env=env)
 
 
-def fasttree(alignment: AlignedDNAFASTAFormat) -> NewickFormat:
+@contextlib.contextmanager
+def _env(**environ):
+    current = os.environ.copy()
+    os.environ.update(environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)
+
+def fasttree(alignment: AlignedDNAFASTAFormat, threads: int=1) -> NewickFormat:
     result = NewickFormat()
     aligned_fp = str(alignment)
     tree_fp = str(result)
-    cmd = ['FastTree', '-quote', '-nt', aligned_fp]
-    run_command(cmd, tree_fp)
+
+    env = os.environ.copy()
+    with _env({'OMP_NUM_THREADS': threads}):
+        cmd = ['FastTreeMP', '-quote', '-nt', aligned_fp]
+        run_command(cmd, tree_fp, env)
     return result

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -53,8 +53,9 @@ plugin.methods.register_function(
                      'runs the non-deterministic variant of `FastTree` '
                      '(`FastTreeMP`), and may result in a different tree than '
                      'single-threading. See '
-                     'http://www.microbesonline.org/fasttree/ for details. '
-                     '(Use -1 to automatically use all available cores)'
+                     'http://www.microbesonline.org/fasttree/#OpenMP for '
+                     'details. (Use -1 to automatically use all available '
+                     'cores)'
     },
     output_descriptions={'tree': 'The resulting phylogenetic tree.'},
     name='Construct a phylogenetic tree with FastTree.',

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -10,7 +10,7 @@ from qiime2.plugin import Plugin
 from q2_types.tree import Phylogeny, Unrooted, Rooted
 from q2_types.feature_data import FeatureData, AlignedSequence
 from q2_types.feature_table import FeatureTable, Frequency
-from qiime2.core.type import Int
+from qiime2.core.type import Int, Range
 
 import q2_phylogeny
 
@@ -42,14 +42,17 @@ plugin.methods.register_function(
 plugin.methods.register_function(
     function=q2_phylogeny.fasttree,
     inputs={'alignment': FeatureData[AlignedSequence]},
-    parameters={'n_threads': Int},
+    parameters={'n_threads': Int % Range(-1, None)},
     outputs=[('tree', Phylogeny[Unrooted])],
     input_descriptions={
         'alignment': ('Aligned sequences to be used for phylogenetic '
                       'reconstruction.')
     },
     parameter_descriptions={
-        'n_threads': 'The number of threads.'
+        'n_threads': 'The number of threads. Using more than one thread '
+                     'runs the non-deterministic variant of `FastTree`, and '
+                     'may result in a different tree than single-threading. '
+                     '(Use -1 to automatically use all available cores)'
     },
     output_descriptions={'tree': 'The resulting phylogenetic tree.'},
     name='Construct a phylogenetic tree with FastTree.',

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -50,8 +50,10 @@ plugin.methods.register_function(
     },
     parameter_descriptions={
         'n_threads': 'The number of threads. Using more than one thread '
-                     'runs the non-deterministic variant of `FastTree`, and '
-                     'may result in a different tree than single-threading. '
+                     'runs the non-deterministic variant of `FastTree` '
+                     '(`FastTreeMP`), and may result in a different tree than '
+                     'single-threading. See '
+                     'http://www.microbesonline.org/fasttree/ for details. '
                      '(Use -1 to automatically use all available cores)'
     },
     output_descriptions={'tree': 'The resulting phylogenetic tree.'},

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -10,6 +10,7 @@ from qiime2.plugin import Plugin
 from q2_types.tree import Phylogeny, Unrooted, Rooted
 from q2_types.feature_data import FeatureData, AlignedSequence
 from q2_types.feature_table import FeatureTable, Frequency
+from qiime2.core.type import Int
 
 import q2_phylogeny
 
@@ -41,7 +42,7 @@ plugin.methods.register_function(
 plugin.methods.register_function(
     function=q2_phylogeny.fasttree,
     inputs={'alignment': FeatureData[AlignedSequence]},
-    parameters={},
+    parameters={'threads': Int},
     outputs=[('tree', Phylogeny[Unrooted])],
     input_descriptions={
         'alignment': ('Aligned sequences to be used for phylogenetic '

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -42,13 +42,15 @@ plugin.methods.register_function(
 plugin.methods.register_function(
     function=q2_phylogeny.fasttree,
     inputs={'alignment': FeatureData[AlignedSequence]},
-    parameters={'threads': Int},
+    parameters={'n_threads': Int},
     outputs=[('tree', Phylogeny[Unrooted])],
     input_descriptions={
         'alignment': ('Aligned sequences to be used for phylogenetic '
                       'reconstruction.')
     },
-    parameter_descriptions={},
+    parameter_descriptions={
+        'n_threads': 'The number of threads.'
+    },
     output_descriptions={'tree': 'The resulting phylogenetic tree.'},
     name='Construct a phylogenetic tree with FastTree.',
     description=("Construct a phylogenetic tree with FastTree.")

--- a/q2_phylogeny/tests/test_fasttree.py
+++ b/q2_phylogeny/tests/test_fasttree.py
@@ -52,14 +52,15 @@ class FastTreeTests(TestPluginBase):
         tip_names.sort()
         self.assertEqual(tip_names, ['_s_e_q_1_', '_s_e_q_2_'])
 
-    def test_fasttree(self):
+    def test_fasttree_n_threads(self):
         input_fp = self.get_data_path('aligned-dna-sequences-1.fasta')
         input_sequences = AlignedDNAFASTAFormat(input_fp, mode='r')
         with redirected_stdio(stderr=os.devnull):
             obs = fasttree(input_sequences, n_threads=-1)
         # load the resulting tree and test that it has the right number of
         # tips and the right tip ids (the branch lengths can vary with
-        # different versions of FastTree)
+        # different versions of FastTree, and threading can produce
+        # non-deterministic trees)
         obs_tree = skbio.TreeNode.read(str(obs))
         tips = list(obs_tree.tips())
         tip_names = [t.name for t in tips]

--- a/q2_phylogeny/tests/test_fasttree.py
+++ b/q2_phylogeny/tests/test_fasttree.py
@@ -52,6 +52,20 @@ class FastTreeTests(TestPluginBase):
         tip_names.sort()
         self.assertEqual(tip_names, ['_s_e_q_1_', '_s_e_q_2_'])
 
+    def test_fasttree(self):
+        input_fp = self.get_data_path('aligned-dna-sequences-1.fasta')
+        input_sequences = AlignedDNAFASTAFormat(input_fp, mode='r')
+        with redirected_stdio(stderr=os.devnull):
+            obs = fasttree(input_sequences, n_threads=-1)
+        # load the resulting tree and test that it has the right number of
+        # tips and the right tip ids (the branch lengths can vary with
+        # different versions of FastTree)
+        obs_tree = skbio.TreeNode.read(str(obs))
+        tips = list(obs_tree.tips())
+        tip_names = [t.name for t in tips]
+        tip_names.sort()
+        self.assertEqual(tip_names, ['seq1', 'seq2'])
+
 
 class RunCommandTests(TestPluginBase):
 


### PR DESCRIPTION
Resolves #35 

~~~For some reason the `env` parameter on `subprocess.run` would not adjust the number of threads used by OpenMP. I had to resort to a context manager with direct os environment manipulation and that successfully limited the threads being used.~~~