### PR TITLE
Update for flake8 v3.6

### DIFF
--- a/q2_phylogeny/_fasttree.py
+++ b/q2_phylogeny/_fasttree.py
@@ -28,7 +28,7 @@ def run_command(cmd, output_fp, verbose=True, env=None):
 
 
 def fasttree(alignment: AlignedDNAFASTAFormat,
-             n_threads: int=1) -> NewickFormat:
+             n_threads: int = 1) -> NewickFormat:
     result = NewickFormat()
     aligned_fp = str(alignment)
     tree_fp = str(result)

--- a/q2_phylogeny/_iqtree.py
+++ b/q2_phylogeny/_iqtree.py
@@ -38,20 +38,20 @@ _iqtree_defaults = {
 
 def _build_iqtree_command(
         alignment,
-        seed: int=_iqtree_defaults['seed'],
-        n_cores: int=_iqtree_defaults['n_cores'],
-        substitution_model: str=_iqtree_defaults['substitution_model'],
-        run_prefix: str=_iqtree_defaults['run_prefix'],
-        dtype: str=_iqtree_defaults['dtype'],
-        n_init_pars_trees: int=_iqtree_defaults['n_init_pars_trees'],
-        n_top_init_trees: int=_iqtree_defaults['n_top_init_trees'],
-        n_best_retain_trees: int=_iqtree_defaults['n_best_retain_trees'],
-        n_iter: int=_iqtree_defaults['n_iter'],
-        stop_iter: int=_iqtree_defaults['stop_iter'],
-        perturb_nni_strength: float=_iqtree_defaults['perturb_nni_strength'],
-        spr_radius: int=_iqtree_defaults['spr_radius'],
-        allnni: bool=_iqtree_defaults['allnni'],
-        safe: bool=_iqtree_defaults['safe']):
+        seed: int = _iqtree_defaults['seed'],
+        n_cores: int = _iqtree_defaults['n_cores'],
+        substitution_model: str = _iqtree_defaults['substitution_model'],
+        run_prefix: str = _iqtree_defaults['run_prefix'],
+        dtype: str = _iqtree_defaults['dtype'],
+        n_init_pars_trees: int = _iqtree_defaults['n_init_pars_trees'],
+        n_top_init_trees: int = _iqtree_defaults['n_top_init_trees'],
+        n_best_retain_trees: int = _iqtree_defaults['n_best_retain_trees'],
+        n_iter: int = _iqtree_defaults['n_iter'],
+        stop_iter: int = _iqtree_defaults['stop_iter'],
+        perturb_nni_strength: float = _iqtree_defaults['perturb_nni_strength'],
+        spr_radius: int = _iqtree_defaults['spr_radius'],
+        allnni: bool = _iqtree_defaults['allnni'],
+        safe: bool = _iqtree_defaults['safe']):
 
     cmd = ['iqtree']
 
@@ -100,18 +100,18 @@ def _build_iqtree_command(
 
 def iqtree(
     alignment: AlignedDNAFASTAFormat,
-    seed: int=_iqtree_defaults['seed'],
-    n_cores: int=_iqtree_defaults['n_cores'],
-    substitution_model: str=_iqtree_defaults['substitution_model'],
-    n_init_pars_trees: int=_iqtree_defaults['n_init_pars_trees'],
-    n_top_init_trees: int=_iqtree_defaults['n_top_init_trees'],
-    n_best_retain_trees: int=_iqtree_defaults['n_best_retain_trees'],
-    n_iter: int=_iqtree_defaults['n_iter'],
-    stop_iter: int=_iqtree_defaults['stop_iter'],
-    perturb_nni_strength: float=_iqtree_defaults['perturb_nni_strength'],
-    spr_radius: int=_iqtree_defaults['spr_radius'],
-    allnni: bool=_iqtree_defaults['allnni'],
-    safe: bool=_iqtree_defaults['safe'],
+    seed: int = _iqtree_defaults['seed'],
+    n_cores: int = _iqtree_defaults['n_cores'],
+    substitution_model: str = _iqtree_defaults['substitution_model'],
+    n_init_pars_trees: int = _iqtree_defaults['n_init_pars_trees'],
+    n_top_init_trees: int = _iqtree_defaults['n_top_init_trees'],
+    n_best_retain_trees: int = _iqtree_defaults['n_best_retain_trees'],
+    n_iter: int = _iqtree_defaults['n_iter'],
+    stop_iter: int = _iqtree_defaults['stop_iter'],
+    perturb_nni_strength: float = _iqtree_defaults['perturb_nni_strength'],
+    spr_radius: int = _iqtree_defaults['spr_radius'],
+    allnni: bool = _iqtree_defaults['allnni'],
+    safe: bool = _iqtree_defaults['safe'],
             ) -> NewickFormat:
     result = NewickFormat()
 
@@ -141,24 +141,24 @@ def iqtree(
 
 def _build_iqtree_ufbs_command(
         alignment,
-        seed: int=_iqtree_defaults['seed'],
-        n_cores: int=_iqtree_defaults['n_cores'],
-        substitution_model: str=_iqtree_defaults['substitution_model'],
-        bootstrap_replicates: int=_iqtree_defaults['bootstrap_replicates'],
-        run_prefix: str=_iqtree_defaults['run_prefix'],
-        dtype: str=_iqtree_defaults['dtype'],
-        n_init_pars_trees: int=_iqtree_defaults['n_init_pars_trees'],
-        n_top_init_trees: int=_iqtree_defaults['n_top_init_trees'],
-        n_best_retain_trees: int=_iqtree_defaults['n_best_retain_trees'],
-        stop_iter: int=_iqtree_defaults['stop_iter'],
-        perturb_nni_strength: float=_iqtree_defaults['perturb_nni_strength'],
-        spr_radius: int=_iqtree_defaults['spr_radius'],
-        n_max_ufboot_iter: int=_iqtree_defaults['n_max_ufboot_iter'],
-        n_ufboot_steps: int=_iqtree_defaults['n_ufboot_steps'],
-        min_cor_ufboot: float=_iqtree_defaults['min_cor_ufboot'],
-        ep_break_ufboot: float=_iqtree_defaults['ep_break_ufboot'],
-        allnni: bool=_iqtree_defaults['allnni'],
-        safe: bool=_iqtree_defaults['safe']):
+        seed: int = _iqtree_defaults['seed'],
+        n_cores: int = _iqtree_defaults['n_cores'],
+        substitution_model: str = _iqtree_defaults['substitution_model'],
+        bootstrap_replicates: int = _iqtree_defaults['bootstrap_replicates'],
+        run_prefix: str = _iqtree_defaults['run_prefix'],
+        dtype: str = _iqtree_defaults['dtype'],
+        n_init_pars_trees: int = _iqtree_defaults['n_init_pars_trees'],
+        n_top_init_trees: int = _iqtree_defaults['n_top_init_trees'],
+        n_best_retain_trees: int = _iqtree_defaults['n_best_retain_trees'],
+        stop_iter: int = _iqtree_defaults['stop_iter'],
+        perturb_nni_strength: float = _iqtree_defaults['perturb_nni_strength'],
+        spr_radius: int = _iqtree_defaults['spr_radius'],
+        n_max_ufboot_iter: int = _iqtree_defaults['n_max_ufboot_iter'],
+        n_ufboot_steps: int = _iqtree_defaults['n_ufboot_steps'],
+        min_cor_ufboot: float = _iqtree_defaults['min_cor_ufboot'],
+        ep_break_ufboot: float = _iqtree_defaults['ep_break_ufboot'],
+        allnni: bool = _iqtree_defaults['allnni'],
+        safe: bool = _iqtree_defaults['safe']):
     # This is a separate command becuase there are several
     # bootstrap specific options.
 
@@ -218,22 +218,22 @@ def _build_iqtree_ufbs_command(
 
 def iqtree_ultrafast_bootstrap(
     alignment: AlignedDNAFASTAFormat,
-    seed: int=_iqtree_defaults['seed'],
-    n_cores: int=_iqtree_defaults['n_cores'],
-    substitution_model: str=_iqtree_defaults['substitution_model'],
-    bootstrap_replicates: int=_iqtree_defaults['bootstrap_replicates'],
-    n_init_pars_trees: int=_iqtree_defaults['n_init_pars_trees'],
-    n_top_init_trees: int=_iqtree_defaults['n_top_init_trees'],
-    n_best_retain_trees: int=_iqtree_defaults['n_best_retain_trees'],
-    stop_iter: int=_iqtree_defaults['stop_iter'],
-    perturb_nni_strength: float=_iqtree_defaults['perturb_nni_strength'],
-    spr_radius: int=_iqtree_defaults['spr_radius'],
-    n_max_ufboot_iter: int=_iqtree_defaults['n_max_ufboot_iter'],
-    n_ufboot_steps: int=_iqtree_defaults['n_ufboot_steps'],
-    min_cor_ufboot: float=_iqtree_defaults['min_cor_ufboot'],
-    ep_break_ufboot: float=_iqtree_defaults['ep_break_ufboot'],
-    allnni: bool=_iqtree_defaults['allnni'],
-    safe: bool=_iqtree_defaults['safe']
+    seed: int = _iqtree_defaults['seed'],
+    n_cores: int = _iqtree_defaults['n_cores'],
+    substitution_model: str = _iqtree_defaults['substitution_model'],
+    bootstrap_replicates: int = _iqtree_defaults['bootstrap_replicates'],
+    n_init_pars_trees: int = _iqtree_defaults['n_init_pars_trees'],
+    n_top_init_trees: int = _iqtree_defaults['n_top_init_trees'],
+    n_best_retain_trees: int = _iqtree_defaults['n_best_retain_trees'],
+    stop_iter: int = _iqtree_defaults['stop_iter'],
+    perturb_nni_strength: float = _iqtree_defaults['perturb_nni_strength'],
+    spr_radius: int = _iqtree_defaults['spr_radius'],
+    n_max_ufboot_iter: int = _iqtree_defaults['n_max_ufboot_iter'],
+    n_ufboot_steps: int = _iqtree_defaults['n_ufboot_steps'],
+    min_cor_ufboot: float = _iqtree_defaults['min_cor_ufboot'],
+    ep_break_ufboot: float = _iqtree_defaults['ep_break_ufboot'],
+    allnni: bool = _iqtree_defaults['allnni'],
+    safe: bool = _iqtree_defaults['safe']
                                 ) -> NewickFormat:
     # NOTE: the IQ-TREE command `-n` (called as `n_iter` in the `iqtree`
     # method) is not compatable with ultrafast_bootstrap `-bb`

--- a/q2_phylogeny/_raxml.py
+++ b/q2_phylogeny/_raxml.py
@@ -45,11 +45,11 @@ def _set_raxml_version(raxml_version='Standard', n_threads=1):
 
 
 def raxml(alignment: AlignedDNAFASTAFormat,
-          seed: int=None,
-          n_searches: int=1,
-          n_threads: int=1,
-          raxml_version: str='Standard',
-          substitution_model: str='GTRGAMMA') -> NewickFormat:
+          seed: int = None,
+          n_searches: int = 1,
+          n_threads: int = 1,
+          raxml_version: str = 'Standard',
+          substitution_model: str = 'GTRGAMMA') -> NewickFormat:
     result = NewickFormat()
 
     cmd = _set_raxml_version(raxml_version=raxml_version, n_threads=n_threads)
@@ -88,10 +88,11 @@ def _build_rapid_bootstrap_command(alignment, seed, rapid_bootstrap_seed,
 
 
 def raxml_rapid_bootstrap(alignment: AlignedDNAFASTAFormat,
-                          seed: int=None, rapid_bootstrap_seed: int=None,
-                          bootstrap_replicates: int=100, n_threads: int=1,
-                          raxml_version: str='Standard',
-                          substitution_model: str='GTRGAMMA') -> NewickFormat:
+                          seed: int = None, rapid_bootstrap_seed: int = None,
+                          bootstrap_replicates: int = 100, n_threads: int = 1,
+                          raxml_version: str = 'Standard',
+                          substitution_model: str = 'GTRGAMMA'
+                          ) -> NewickFormat:
     result = NewickFormat()
     cmd = _set_raxml_version(raxml_version=raxml_version, n_threads=n_threads)
 

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,5 +1,6 @@
 
 # Version: 0.18
+# flake8: noqa
 
 """The Versioneer - like a rocketeer, but for versions.
 


### PR DESCRIPTION
Numerous minor updates for compliance with flake8 v3.6, as discussed in qiime2/qiime2#415
Note: flake8 has been disabled in versioneer.py.