### PR TITLE
IMP: q2-phylogeny : iqtree

### DIFF
--- a/q2_phylogeny/_iqtree.py
+++ b/q2_phylogeny/_iqtree.py
@@ -16,6 +16,7 @@ from q2_phylogeny._raxml import run_command
 _iqtree_defaults = {
     'seed': None,
     'n_cores': 1,
+    'n_cores_max': None,
     'n_runs': 1,
     'substitution_model': 'MFP',
     'run_prefix': 'q2iqtree',
@@ -46,6 +47,7 @@ def _build_iqtree_command(
         alignment,
         seed: int = _iqtree_defaults['seed'],
         n_cores: int = _iqtree_defaults['n_cores'],
+        n_cores_max: int = _iqtree_defaults['n_cores_max'],
         n_runs: int = _iqtree_defaults['n_runs'],
         substitution_model: str = _iqtree_defaults['substitution_model'],
         run_prefix: str = _iqtree_defaults['run_prefix'],
@@ -72,7 +74,9 @@ def _build_iqtree_command(
             '-m', str(substitution_model),
             '-pre', str(run_prefix)]
 
-    if n_cores == 'auto':
+    if n_cores == 'auto' and n_cores_max:
+        cmd += ['-nt', 'AUTO', '--threads-max', '%i' % n_cores_max]
+    elif n_cores == 'auto' and n_cores_max is None:
         cmd += ['-nt', 'AUTO']
     else:
         cmd += ['-nt', '%i' % n_cores]
@@ -126,6 +130,7 @@ def iqtree(
     alignment: AlignedDNAFASTAFormat,
     seed: int = _iqtree_defaults['seed'],
     n_cores: int = _iqtree_defaults['n_cores'],
+    n_cores_max: int = _iqtree_defaults['n_cores_max'],
     n_runs: int = _iqtree_defaults['n_runs'],
     substitution_model: str = _iqtree_defaults['substitution_model'],
     n_init_pars_trees: int = _iqtree_defaults['n_init_pars_trees'],
@@ -149,6 +154,7 @@ def iqtree(
         cmd = _build_iqtree_command(alignment,
                                     seed=seed,
                                     n_cores=n_cores,
+                                    n_cores_max=n_cores_max,
                                     n_runs=n_runs,
                                     substitution_model=substitution_model,
                                     run_prefix=run_prefix,
@@ -177,6 +183,7 @@ def _build_iqtree_ufbs_command(
         alignment,
         seed: int = _iqtree_defaults['seed'],
         n_cores: int = _iqtree_defaults['n_cores'],
+        n_cores_max: int = _iqtree_defaults['n_cores_max'],
         n_runs:  int = _iqtree_defaults['n_runs'],
         substitution_model: str = _iqtree_defaults['substitution_model'],
         bootstrap_replicates: int = _iqtree_defaults['bootstrap_replicates'],
@@ -209,7 +216,9 @@ def _build_iqtree_ufbs_command(
             '-m', str(substitution_model),
             '-pre', str(run_prefix)]
 
-    if n_cores == 'auto':
+    if n_cores == 'auto' and n_cores_max:
+        cmd += ['-nt', 'AUTO', '--threads-max', '%i' % n_cores_max]
+    elif n_cores == 'auto' and n_cores_max is None:
         cmd += ['-nt', 'AUTO']
     else:
         cmd += ['-nt', '%i' % n_cores]
@@ -272,6 +281,7 @@ def iqtree_ultrafast_bootstrap(
     alignment: AlignedDNAFASTAFormat,
     seed: int = _iqtree_defaults['seed'],
     n_cores: int = _iqtree_defaults['n_cores'],
+    n_cores_max: int = _iqtree_defaults['n_cores_max'],
     n_runs: int = _iqtree_defaults['n_runs'],
     substitution_model: str = _iqtree_defaults['substitution_model'],
     bootstrap_replicates: int = _iqtree_defaults['bootstrap_replicates'],
@@ -302,6 +312,7 @@ def iqtree_ultrafast_bootstrap(
                     alignment,
                     seed=seed,
                     n_cores=n_cores,
+                    n_cores_max=n_cores_max,
                     n_runs=n_runs,
                     substitution_model=substitution_model,
                     bootstrap_replicates=bootstrap_replicates,

--- a/q2_phylogeny/citations.bib
+++ b/q2_phylogeny/citations.bib
@@ -35,16 +35,16 @@
     URL = {http://dx.doi.org/10.1080/10635150802429642},
 }
 
-@article{Nguyen2015iqtree,
-    author = {Nguyen, Lam-Tung and Schmidt, Heiko A. and von Haeseler, Arndt and Minh, Bui Quang},
-    title = {IQ-TREE: A Fast and Effective Stochastic Algorithm for Estimating Maximum-Likelihood Phylogenies},
-    journal = {Molecular Biology and Evolution},
-    volume = {32},
-    number = {1},
-    pages = {268-274},
-    year = {2015},
-    doi = {10.1093/molbev/msu300},
-    URL = {http://dx.doi.org/10.1093/molbev/msu300},
+@article{Minh2020iqtree,
+  title = {IQ-TREE 2: New Models and Efficient Methods for Phylogenetic Inference in the Genomic Era},
+  author = {Minh, Bui Quang and Schmidt, Heiko A and Chernomor, Olga and Schrempf, Dominik and Woodhams, Michael D and von Haeseler, Arndt and Lanfear, Robert},
+  journal = {Molecular Biology and Evolution},
+  volume =  {37},
+  number =  {5},
+  pages = {1530-1534},
+  year =  {2020},
+  doi = {10.1093/molbev/msaa015},
+  URL = {http://dx.doi.org/10.1093/molbev/msaa015},
 }
 
 @article{Kalyaanamoorthy2017modelfinder,

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -210,6 +210,7 @@ plugin.methods.register_function(
     parameters={
             'seed': Int,
             'n_cores': Int % Range(1, None) | Str % Choices(['auto']),
+            'n_cores_max': Int % Range(2, None),
             'n_runs': Int % Range(1, None),
             'substitution_model': Str % Choices(_IQTREE_DNA_MODELS),
             'n_init_pars_trees': Int % Range(1, None),
@@ -234,6 +235,8 @@ plugin.methods.register_function(
         'n_cores': ('The number of cores to use for parallel '
                     'processing. Use `auto` to let IQ-TREE automatically '
                     'determine the optimal number of cores to use.'),
+        'n_cores_max': ('Limits the maximum number of cores to be used '
+                        'when \'n_cores\' is set to \'auto\'.'),
         'n_runs': ('Number of indepedent runs. Multiple  independent runs '
                    '(e.g. 10) can outperform a single run in terms of '
                    'likelihood maximisation.'),
@@ -282,7 +285,7 @@ plugin.methods.register_function(
     name='Construct a phylogenetic tree with IQ-TREE.',
     description=('Construct a phylogenetic tree using IQ-TREE '
                  '(http://www.iqtree.org/) with automatic model selection.'),
-    citations=[citations['Nguyen2015iqtree'],
+    citations=[citations['Minh2020iqtree'],
                citations['Kalyaanamoorthy2017modelfinder']]
 )
 
@@ -292,6 +295,7 @@ plugin.methods.register_function(
     parameters={
             'seed': Int,
             'n_cores': Int % Range(1, None) | Str % Choices(['auto']),
+            'n_cores_max': Int % Range(2, None),
             'n_runs': Int % Range(1, None),
             'substitution_model': Str % Choices(_IQTREE_DNA_MODELS),
             'n_init_pars_trees': Int % Range(1, None),
@@ -320,6 +324,8 @@ plugin.methods.register_function(
         'n_cores': ('The number of cores to use for parallel '
                     'processing. Use `auto` to let IQ-TREE automatically '
                     'determine the optimal number of cores to use.'),
+        'n_cores_max': ('Limits the maximum number of cores to be used '
+                        'when \'n_cores\' is set to \'auto\'.'),
         'n_runs': ('Number of indepedent runs. Multiple  independent runs '
                    '(e.g. 10) can outperform a single run in terms of '
                    'likelihood maximisation.'),
@@ -386,7 +392,7 @@ plugin.methods.register_function(
     description=('Construct a phylogenetic tree using IQ-TREE '
                  '(http://www.iqtree.org/) with automatic '
                  'model selection and bootstrap supports.'),
-    citations=[citations['Nguyen2015iqtree'],
+    citations=[citations['Minh2020iqtree'],
                citations['Kalyaanamoorthy2017modelfinder'],
                citations['Minh2013ultrafastbootstrap'],
                citations['Hoang2017ultrafastbootstrap2']]

--- a/q2_phylogeny/tests/test_iqtree.py
+++ b/q2_phylogeny/tests/test_iqtree.py
@@ -118,6 +118,26 @@ class IqtreeTests(TestPluginBase):
                               'GCA000686145', 'GCA001950115', 'GCA001971985',
                               'GCA900007555']))
 
+    def test_iqtree_n_cores_auto_max(self):
+        # Test that an output tree is made when invoking automatic threads.
+        input_fp = self.get_data_path('aligned-dna-sequences-3.fasta')
+        input_sequences = AlignedDNAFASTAFormat(input_fp, mode='r')
+
+        with redirected_stdio(stderr=os.devnull):
+            obs = iqtree(input_sequences, n_cores='auto', n_cores_max=2)
+        obs_tree = skbio.TreeNode.read(str(obs), convert_underscores=False)
+
+        # load the resulting tree and test that it has the right number of
+        # tips and the right tip ids
+        tips = list(obs_tree.tips())
+        tip_names = [t.name for t in tips]
+
+        self.assertEqual(set(tip_names),
+                         set(['GCA001510755', 'GCA001045515', 'GCA000454205',
+                              'GCA000473545', 'GCA000196255', 'GCA002142615',
+                              'GCA000686145', 'GCA001950115', 'GCA001971985',
+                              'GCA900007555']))
+
     def test_iqtree_with_seed(self):
         # Test tip-to-tip dists are identical to manually run IQ-TREE output.
         # This test is comparing an ordered series of tip-to-tip distances
@@ -181,6 +201,7 @@ class IqtreeTests(TestPluginBase):
                 obs = _build_iqtree_command(input_sequences,
                                             seed=1723,
                                             n_cores='auto',
+                                            n_cores_max=4,
                                             n_runs=2,
                                             substitution_model='MFP',
                                             run_prefix=run_prefix,
@@ -204,20 +225,21 @@ class IqtreeTests(TestPluginBase):
         self.assertTrue('MFP' in obs[8])
         self.assertTrue(str(run_prefix) in obs[10])
         self.assertTrue('AUTO' in obs[12])
-        self.assertTrue('1723' in obs[14])
-        self.assertTrue(str('-safe') in obs[15])
-        self.assertTrue(str('-fast') in obs[16])
-        self.assertTrue(str('1000') in obs[18])
-        self.assertTrue(str('-abayes') in obs[19])
-        self.assertTrue(str('1000') in obs[21])
-        self.assertTrue(str('-allnni') in obs[22])
-        self.assertTrue(str('200') in obs[24])
-        self.assertTrue(str('30') in obs[26])
-        self.assertTrue(str('10') in obs[28])
-        self.assertTrue(str('80') in obs[30])
-        self.assertTrue(str('300') in obs[32])
-        self.assertTrue(str('0.55') in obs[34])
-        self.assertTrue(str('8') in obs[36])
+        self.assertTrue('4' in obs[14])
+        self.assertTrue('1723' in obs[16])
+        self.assertTrue(str('-safe') in obs[17])
+        self.assertTrue(str('-fast') in obs[18])
+        self.assertTrue(str('1000') in obs[20])
+        self.assertTrue(str('-abayes') in obs[21])
+        self.assertTrue(str('1000') in obs[23])
+        self.assertTrue(str('-allnni') in obs[24])
+        self.assertTrue(str('200') in obs[26])
+        self.assertTrue(str('30') in obs[28])
+        self.assertTrue(str('10') in obs[30])
+        self.assertTrue(str('80') in obs[32])
+        self.assertTrue(str('300') in obs[34])
+        self.assertTrue(str('0.55') in obs[36])
+        self.assertTrue(str('8') in obs[38])
 
     def test_build_iqtree_ufbs_command(self):
         input_fp = self.get_data_path('aligned-dna-sequences-3.fasta')
@@ -228,6 +250,7 @@ class IqtreeTests(TestPluginBase):
                 obs = _build_iqtree_ufbs_command(input_sequences,
                                                  seed=1723,
                                                  n_cores='auto',
+                                                 n_cores_max=6,
                                                  n_runs=5,
                                                  bootstrap_replicates=2000,
                                                  substitution_model='MFP',
@@ -256,23 +279,24 @@ class IqtreeTests(TestPluginBase):
         self.assertTrue('MFP' in obs[10])
         self.assertTrue(str(run_prefix) in obs[12])
         self.assertTrue('AUTO' in obs[14])
-        self.assertTrue('1723' in obs[16])
-        self.assertTrue('-safe' in obs[17])
-        self.assertTrue('-allnni' in obs[18])
-        self.assertTrue('500' in obs[20])
-        self.assertTrue('-abayes' in obs[21])
-        self.assertTrue('400' in obs[23])
-        self.assertTrue('-bnni' in obs[24])
-        self.assertTrue('200' in obs[26])
-        self.assertTrue(str('30') in obs[28])
-        self.assertTrue(str('10') in obs[30])
-        self.assertTrue(str('300') in obs[32])
-        self.assertTrue(str('0.55') in obs[34])
-        self.assertTrue(str('8') in obs[36])
-        self.assertTrue(str('600') in obs[38])
-        self.assertTrue(str('80') in obs[40])
-        self.assertTrue(str('0.66') in obs[42])
-        self.assertTrue(str('0.51') in obs[44])
+        self.assertTrue('6' in obs[16])
+        self.assertTrue('1723' in obs[18])
+        self.assertTrue('-safe' in obs[19])
+        self.assertTrue('-allnni' in obs[20])
+        self.assertTrue('500' in obs[22])
+        self.assertTrue('-abayes' in obs[23])
+        self.assertTrue('400' in obs[25])
+        self.assertTrue('-bnni' in obs[26])
+        self.assertTrue('200' in obs[28])
+        self.assertTrue(str('30') in obs[30])
+        self.assertTrue(str('10') in obs[32])
+        self.assertTrue(str('300') in obs[34])
+        self.assertTrue(str('0.55') in obs[36])
+        self.assertTrue(str('8') in obs[38])
+        self.assertTrue(str('600') in obs[40])
+        self.assertTrue(str('80') in obs[42])
+        self.assertTrue(str('0.66') in obs[44])
+        self.assertTrue(str('0.51') in obs[46])
 
     def test_iqtree_ultrafast_bootstrap(self):
         # Test that output tree is made.
@@ -344,6 +368,25 @@ class IqtreeTests(TestPluginBase):
         input_sequences = AlignedDNAFASTAFormat(input_fp, mode='r')
         with redirected_stdio(stderr=os.devnull):
             obs = iqtree_ultrafast_bootstrap(input_sequences, n_cores='auto')
+        obs_tree = skbio.TreeNode.read(str(obs))
+        # load the resulting tree and test that it has the right number of
+        # tips and the right tip ids
+        tips = list(obs_tree.tips())
+        tip_names = [t.name for t in tips]
+        self.assertEqual(set(tip_names),
+                         set(['GCA001510755', 'GCA001045515', 'GCA000454205',
+                              'GCA000473545', 'GCA000196255', 'GCA002142615',
+                              'GCA000686145', 'GCA001950115', 'GCA001971985',
+                              'GCA900007555']))
+
+    def test_iqtree_ultrafast_bootstrap_auto_threads_max(self):
+        # Test that output tree is made after auto optimizing threads.
+        # Reads tree output and compares tip labels to expected labels.
+        input_fp = self.get_data_path('aligned-dna-sequences-3.fasta')
+        input_sequences = AlignedDNAFASTAFormat(input_fp, mode='r')
+        with redirected_stdio(stderr=os.devnull):
+            obs = iqtree_ultrafast_bootstrap(input_sequences, n_cores='auto',
+                                             n_cores_max=2)
         obs_tree = skbio.TreeNode.read(str(obs))
         # load the resulting tree and test that it has the right number of
         # tips and the right tip ids


### PR DESCRIPTION
Minor update and usability improvement for `iqtree` and `iqtree-ultrafast-bootstrap`. Both of which now include:

- Citation now points to [IQ-TREE 2](http://dx.doi.org/10.1093/molbev/msaa015).
- Added the parameter `n_cores_max`. This is to be used when `n_cores auto` is set. That is, `n_cores_max` will limit how many cores `auto` is allowed to scale too. 
- Added / updated associated test cases.