### PR TITLE
dep: pinning iqtree <2.1.0

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - q2-alignment {{ release }}.*
     - fasttree 2.1.10=0
     - raxml
-    - iqtree >=1.6.4
+    - iqtree >=1.6.4,<2.1.0
 
 test:
   imports:


### PR DESCRIPTION
cc @mikerobeson  - I'll file an issue for this later, but it looks like the latest iqtree is causing some test failures: https://github.com/qiime2/q2-phylogeny/runs/2250221637?check_suite_focus=true