### PR TITLE
dep: min pin iqtree 2.2.0.3

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     # https://github.com/bioconda/bioconda-recipes/blob/master/recipes/fasttree/build.sh
     - fasttree ==2.1.10=0
     - raxml
-    - iqtree >=1.6.4
+    - iqtree >=2.2.0.3
     - pytest
 
 test:


### PR DESCRIPTION
This version of iqtree is currently failing to integrate into the core distro, so re-running the tests here for a closer look.

- https://github.com/qiime2/package-integration/actions/workflows/cron-2022.4-core-macos-latest.yaml
- https://github.com/qiime2/package-integration/actions/workflows/cron-2022.4-core-ubuntu-latest.yaml

cc @mikerobeson 