### PR TITLE
dep: pin iqtree 2.2.0_beta

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -26,7 +26,7 @@ requirements:
     # https://github.com/bioconda/bioconda-recipes/blob/master/recipes/fasttree/build.sh
     - fasttree ==2.1.10=0
     - raxml
-    - iqtree >=1.6.4
+    - iqtree ==2.2.0_beta
     - pytest
 
 test:


### PR DESCRIPTION
While we're sorting out https://github.com/qiime2/q2-phylogeny/pull/86 let's pin iqtree to unstick package integration.

cc @mikerobeson 