### PR TITLE
ex: adds align_to_tree_mafft_fasttree example

### DIFF
--- a/q2_phylogeny/_examples.py
+++ b/q2_phylogeny/_examples.py
@@ -1,0 +1,31 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2022, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+
+rep_seqs_url = ('https://data.qiime2.org/usage-examples/'
+                'moving-pictures/rep-seqs-dada2.qza')
+
+
+def phylogeny_align_to_tree_mafft_fasttree(use):
+    rep_seqs = use.init_artifact_from_url('rep_seqs', rep_seqs_url)
+
+    alignment, masked_alignment, tree, rooted_tree = use.action(
+        use.UsageAction('phylogeny', 'align_to_tree_mafft_fasttree'),
+        use.UsageInputs(sequences=rep_seqs),
+        use.UsageOutputNames(
+            alignment='aligned-rep-seqs',
+            masked_alignment='masked-aligned-rep-seqs',
+            tree='unrooted-tree',
+            rooted_tree='rooted-tree',
+        )
+    )
+
+    alignment.assert_output_type('FeatureData[AlignedSequence]')
+    masked_alignment.assert_output_type('FeatureData[AlignedSequence]')
+    tree.assert_output_type('Phylogeny[Unrooted]')
+    rooted_tree.assert_output_type('Phylogeny[Rooted]')

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -16,6 +16,7 @@ from q2_types.feature_table import (FeatureTable, Frequency,
 from q2_types.distance_matrix import DistanceMatrix
 
 import q2_phylogeny
+import q2_phylogeny._examples as ex
 
 _RAXML_MODEL_OPT = ['GTRGAMMA', 'GTRGAMMAI', 'GTRCAT', 'GTRCATI']
 _RAXML_VERSION_OPT = ['Standard', 'SSE3', 'AVX2']
@@ -554,7 +555,11 @@ plugin.pipelines.register_function(
                  'masked MAFFT alignment from q2-alignment methods, and both '
                  'the rooted and unrooted phylogenies from q2-phylogeny '
                  'methods.'
-                 )
+                 ),
+    examples={
+        'align_to_tree_mafft_fasttree':
+        ex.phylogeny_align_to_tree_mafft_fasttree,
+    }
 )
 
 plugin.pipelines.register_function(

--- a/q2_phylogeny/tests/test_examples.py
+++ b/q2_phylogeny/tests/test_examples.py
@@ -1,0 +1,16 @@
+# ----------------------------------------------------------------------------
+# Copyright (c) 2016-2022, QIIME 2 development team.
+#
+# Distributed under the terms of the Modified BSD License.
+#
+# The full license is in the file LICENSE, distributed with this software.
+# ----------------------------------------------------------------------------
+
+from qiime2.plugin.testing import TestPluginBase
+
+
+class TestUsageExample(TestPluginBase):
+    package = 'q2_phylogeny.tests'
+
+    def test_usage_examples(self):
+        self.execute_examples()


### PR DESCRIPTION
This PR adds a usage example for `align_to_tree_mafft_fasttree`.