### PR TITLE
Expose parttree and large MAFFT parameters to pipelines

### DIFF
--- a/q2_phylogeny/_align_to_tree_mafft_fasttree.py
+++ b/q2_phylogeny/_align_to_tree_mafft_fasttree.py
@@ -10,14 +10,15 @@
 def align_to_tree_mafft_fasttree(ctx, sequences, n_threads=1,
                                  mask_max_gap_frequency=1.0,
                                  mask_min_conservation=0.40,
-                                 parttree=False):
+                                 parttree=False,
+                                 large=False):
     mafft = ctx.get_action('alignment', 'mafft')
     mask = ctx.get_action('alignment', 'mask')
     fasttree = ctx.get_action('phylogeny', 'fasttree')
     midpoint_root = ctx.get_action('phylogeny', 'midpoint_root')
 
     aligned_seq, = mafft(sequences=sequences, n_threads=n_threads,
-                         parttree=parttree)
+                         parttree=parttree, large=large)
     masked_seq, = mask(alignment=aligned_seq,
                        max_gap_frequency=mask_max_gap_frequency,
                        min_conservation=mask_min_conservation)

--- a/q2_phylogeny/_align_to_tree_mafft_iqtree.py
+++ b/q2_phylogeny/_align_to_tree_mafft_iqtree.py
@@ -10,6 +10,8 @@
 def align_to_tree_mafft_iqtree(ctx, sequences, n_threads=1,
                                mask_max_gap_frequency=1.0,
                                mask_min_conservation=0.40,
+                               parttree=False,
+                               large=False,
                                substitution_model='MFP',
                                fast=False, alrt=None,
                                seed=None, stop_iter=None,
@@ -19,7 +21,8 @@ def align_to_tree_mafft_iqtree(ctx, sequences, n_threads=1,
     iqtree = ctx.get_action('phylogeny', 'iqtree')
     midpoint_root = ctx.get_action('phylogeny', 'midpoint_root')
 
-    aligned_seq, = mafft(sequences=sequences, n_threads=n_threads)
+    aligned_seq, = mafft(sequences=sequences, n_threads=n_threads,
+                         parttree=parttree, large=large)
     masked_seq, = mask(alignment=aligned_seq,
                        max_gap_frequency=mask_max_gap_frequency,
                        min_conservation=mask_min_conservation)

--- a/q2_phylogeny/_align_to_tree_mafft_raxml.py
+++ b/q2_phylogeny/_align_to_tree_mafft_raxml.py
@@ -11,6 +11,7 @@ def align_to_tree_mafft_raxml(ctx, sequences, n_threads=1,
                               mask_max_gap_frequency=1.0,
                               mask_min_conservation=0.40,
                               parttree=False,
+                              large=False,
                               substitution_model='GTRGAMMA',
                               seed=None, raxml_version='Standard'):
     mafft = ctx.get_action('alignment', 'mafft')
@@ -19,7 +20,7 @@ def align_to_tree_mafft_raxml(ctx, sequences, n_threads=1,
     midpoint_root = ctx.get_action('phylogeny', 'midpoint_root')
 
     aligned_seq, = mafft(sequences=sequences, n_threads=n_threads,
-                         parttree=parttree)
+                         parttree=parttree, large=large)
     masked_seq, = mask(alignment=aligned_seq,
                        max_gap_frequency=mask_max_gap_frequency,
                        min_conservation=mask_min_conservation)

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -540,9 +540,9 @@ plugin.pipelines.register_function(
                     'aligned are larger than 1000000. Disabled by default.',
         'large': 'This flag is required when aligning very large datasets '
                  'that do not otherwise fit into memory. Temporary data is '
-                 'then stored in files, instead of RAM. The --use-cache '
-                 'flag specifies the storage location of the temporary files '
-                 'created. By default, $TMP/qiime2/ is used.',
+                 'then stored in files, instead of RAM. The temporary files '
+                 'are stored in the QIIME 2 Artifact cache. The default '
+                 'location of the cache is $TMP/qiime2/<uname>.',
     },
     output_descriptions={
         'alignment': 'The aligned sequences.',
@@ -625,9 +625,9 @@ plugin.pipelines.register_function(
                     'aligned are larger than 1000000. Disabled by default.',
         'large': 'This flag is required when aligning very large datasets '
                  'that do not otherwise fit into memory. Temporary data is '
-                 'then stored in files, instead of RAM. The --use-cache '
-                 'flag specifies the storage location of the temporary files '
-                 'created. By default, $TMP/qiime2/ is used.',
+                 'then stored in files, instead of RAM. The temporary files '
+                 'are stored in the QIIME 2 Artifact cache. The default '
+                 'location of the cache is $TMP/qiime2/<uname>.',
         'seed':  'Random number seed for the iqtree parsimony starting tree. '
                  'This allows you to reproduce tree results. '
                  'If not supplied then one will be randomly chosen.',

--- a/q2_phylogeny/plugin_setup.py
+++ b/q2_phylogeny/plugin_setup.py
@@ -499,6 +499,7 @@ plugin.pipelines.register_function(
         'mask_max_gap_frequency': Float % Range(0, 1, inclusive_end=True),
         'mask_min_conservation': Float % Range(0, 1, inclusive_end=True),
         'parttree': Bool,
+        'large': Bool,
     },
     outputs=[
         ('alignment', FeatureData[AlignedSequence]),
@@ -537,6 +538,11 @@ plugin.pipelines.register_function(
                                   'aligned sequences.',
         'parttree': 'This flag is required if the number of sequences being '
                     'aligned are larger than 1000000. Disabled by default.',
+        'large': 'This flag is required when aligning very large datasets '
+                 'that do not otherwise fit into memory. Temporary data is '
+                 'then stored in files, instead of RAM. The --use-cache '
+                 'flag specifies the storage location of the temporary files '
+                 'created. By default, $TMP/qiime2/ is used.',
     },
     output_descriptions={
         'alignment': 'The aligned sequences.',
@@ -571,6 +577,8 @@ plugin.pipelines.register_function(
         'n_threads': Threads,
         'mask_max_gap_frequency': Float % Range(0, 1, inclusive_end=True),
         'mask_min_conservation': Float % Range(0, 1, inclusive_end=True),
+        'parttree': Bool,
+        'large': Bool,
         'seed': Int,
         'substitution_model': Str % Choices(_IQTREE_DNA_MODELS),
         'stop_iter': Int % Range(1, None),
@@ -613,6 +621,13 @@ plugin.pipelines.register_function(
                                   'present in at least 40% of the sequences. '
                                   'This value is used when masking the '
                                   'aligned sequences.',
+        'parttree': 'This flag is required if the number of sequences being '
+                    'aligned are larger than 1000000. Disabled by default.',
+        'large': 'This flag is required when aligning very large datasets '
+                 'that do not otherwise fit into memory. Temporary data is '
+                 'then stored in files, instead of RAM. The --use-cache '
+                 'flag specifies the storage location of the temporary files '
+                 'created. By default, $TMP/qiime2/ is used.',
         'seed':  'Random number seed for the iqtree parsimony starting tree. '
                  'This allows you to reproduce tree results. '
                  'If not supplied then one will be randomly chosen.',
@@ -663,6 +678,7 @@ plugin.pipelines.register_function(
         'mask_max_gap_frequency': Float % Range(0, 1, inclusive_end=True),
         'mask_min_conservation': Float % Range(0, 1, inclusive_end=True),
         'parttree': Bool,
+        'large': Bool,
         'seed': Int,
         'substitution_model': Str % Choices(_RAXML_MODEL_OPT),
         'raxml_version': Str % Choices(_RAXML_VERSION_OPT),
@@ -706,6 +722,11 @@ plugin.pipelines.register_function(
                     'NOTE: if using this option, it is recomended that only '
                     'the CAT-based substitution models of RAxML be '
                     'considered for this pipeline.',
+        'large': 'This flag is required when aligning very large datasets '
+                 'that do not otherwise fit into memory. Temporary data is '
+                 'then stored in files, instead of RAM. The --use-cache '
+                 'flag specifies the storage location of the temporary files '
+                 'created. By default, $TMP/qiime2/ is used.',
         'seed':  'Random number seed for the parsimony starting tree. '
                  'This allows you to reproduce tree results. '
                  'If not supplied then one will be randomly chosen.',


### PR DESCRIPTION
Addresses issue [#104](https://github.com/qiime2/q2-phylogeny/issues/104) by exposing the MAFFT parameter `--parttree` to the pipeline `align-to-tree-mafft-iqtree`. In addition, it exposes the MAFFT parameter `--large` to the pipelines `align-to-tree-mafft-fasttree`, `align-to-tree-mafft-iqtree`, and `align-to-tree-mafft-raxml`.