### PR TITLE
Update root_at_midpoint to new default

### DIFF
--- a/q2_phylogeny/_util.py
+++ b/q2_phylogeny/_util.py
@@ -10,7 +10,7 @@ import skbio
 
 
 def midpoint_root(tree: skbio.TreeNode) -> skbio.TreeNode:
-    return tree.root_at_midpoint()
+    return tree.root_at_midpoint(reset=True, branch_attrs=[], root_name=None)
 
 
 def robinson_foulds(trees: skbio.TreeNode, labels: str = None,


### PR DESCRIPTION
Addresses issue [#107](https://github.com/qiime2/q2-phylogeny/issues/107) by applying the suggested changes to the `root_at_midpoint` function. This removes both warnings described in the issue, since `unrooted_copy` is never directly called in the pipeline itself, but is dependent on the parameters set in the former function.